### PR TITLE
count ancilla for all logical qubits

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -106,8 +106,9 @@ const QuantumCalculator = () => {
         // Calculate code distance based on number of data qubits per logical qubit
         result.d = Math.floor(Math.sqrt(params.n / params.k));
         
-        // Calculate number of ancilla qubits
-        result.n_ancilla = Math.pow(result.d - 1, 2) + 2 * (result.d - 1);
+        // Calculate number of ancilla qubits for all logical qubits
+        // Each logical qubit requires (d-1)^2 + 2(d-1) ancilla qubits
+        result.n_ancilla = params.k * (Math.pow(result.d - 1, 2) + 2 * (result.d - 1));
         
         // Calculate logical error rate
         result.epsilon_L = 0.03 * params.k * Math.pow(p_ratio, result.d / 2);


### PR DESCRIPTION
This pull request includes an important change to the calculation of ancilla qubits in the `QuantumCalculator` component. The update ensures that the number of ancilla qubits is calculated for all logical qubits rather than just one.

Changes to ancilla qubit calculation:

* [`src/App.js`](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67L109-R111): Modified the calculation of `result.n_ancilla` to account for all logical qubits by multiplying the previous formula by `params.k`. This ensures each logical qubit's ancilla qubits are included in the total.