### PR TITLE
total qubit count

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -426,6 +426,12 @@ const QuantumCalculator = () => {
                 </div>
               )}
               
+              {results.n && results.n_ancilla && (
+                <div className="border-b pb-2">
+                  <span className="font-medium">Total Qubits (n+n_a):</span> {Math.ceil(results.n + results.n_ancilla).toLocaleString()}
+                </div>
+              )}
+              
               {results.k && (
                 <div className="border-b pb-2">
                   <span className="font-medium">Logical Qubits (k):</span> {results.k}


### PR DESCRIPTION
This pull request includes a new feature to display the total number of qubits in the `QuantumCalculator` component in the `src/App.js` file.

Feature addition:

* [`src/App.js`](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67R429-R434): Added a new section to display the total number of qubits (`n + n_ancilla`) when both `results.n` and `results.n_ancilla` are available.