### PR TITLE
Feat/color code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An interactive web tool for estimating quantum computing resource requirements w
   - Surface Code
   - Hypergraph Product Code
   - Lifted Product Code
+  - Color Code
 
 - **Interactive Calculator:**
   - Adjustable parameters for physical error rate (p)
@@ -43,6 +44,13 @@ An interactive web tool for estimating quantum computing resource requirements w
 - Threshold ≈ 0.66%
 
 Reference for HGP and LP codes: [Constant-Overhead Fault-Tolerant Quantum Computation with Reconfigurable Atom Arrays (Xu et al., 2023)](https://arxiv.org/abs/2308.08648v1)
+
+### Color Code
+- LFR(color) = 0.03k(p/0.0036)^⌈d/2⌉
+- Threshold ≈ 0.36% (circuit-level noise)
+- d ≈ √(n/k) for triangular honeycomb (6.6.6) patches
+
+Formula for triangular color code patches. Steane code [[7,1,3]] is the d=3 member. Uses the same functional form as surface code but with [lower threshold for circuit-level noise](https://doi.org/10.1103/PRXQuantum.5.030352).
 
 ## Getting Started
 

--- a/src/App.js
+++ b/src/App.js
@@ -568,6 +568,17 @@ const QuantumCalculator = () => {
                   tension: 0.1,
                   showLine: true
                 },
+                {
+                  label: `${codeLibrary['color'].name} (ε_L = ${inputs.epsilon_L.toExponential(1)})`,
+                  data: generatePlotData('color', inputs.epsilon_L, inputs.k)?.pValues.map((p, i) => ({
+                    x: p,
+                    y: generatePlotData('color', inputs.epsilon_L, inputs.k)?.nValues[i]
+                  })),
+                  borderColor: 'rgb(147, 51, 234)',
+                  backgroundColor: 'rgba(147, 51, 234, 0.1)',
+                  tension: 0.1,
+                  showLine: true
+                },
                 // Vertical threshold lines
                 {
                   label: `Surface Code Threshold (${(codeLibrary['surface'].threshold * 100).toFixed(2)}%)`,
@@ -605,6 +616,20 @@ const QuantumCalculator = () => {
                   ],
                   borderColor: 'rgb(255, 159, 64)',
                   backgroundColor: 'rgb(255, 159, 64)',
+                  borderWidth: 2,
+                  borderDash: [5, 5],
+                  pointRadius: 0,
+                  showLine: true,
+                  tension: 0
+                },
+                {
+                  label: `Color Code Threshold (${(codeLibrary['color'].threshold * 100).toFixed(2)}%)`,
+                  data: [
+                    { x: codeLibrary['color'].threshold, y: 10 },
+                    { x: codeLibrary['color'].threshold, y: 100 }
+                  ],
+                  borderColor: 'rgb(147, 51, 234)',
+                  backgroundColor: 'rgb(147, 51, 234)',
                   borderWidth: 2,
                   borderDash: [5, 5],
                   pointRadius: 0,

--- a/src/App.js
+++ b/src/App.js
@@ -122,6 +122,32 @@ const QuantumCalculator = () => {
         return result;
       }
     },
+    color: {
+      name: 'Color Code',
+      threshold: 0.0036, // 0.36% (circuit-level noise)
+      calculateParams: (params) => {
+        let result = {};
+        const p_ratio = params.p / 0.0036; // Using circuit-level threshold
+        
+        // Calculate code distance based on number of data qubits per logical qubit
+        // For triangular honeycomb (6.6.6) color codes, d ≈ √(n/k)
+        result.d = Math.floor(Math.sqrt(params.n / params.k));
+        
+        // Calculate number of ancilla qubits for all logical qubits
+        // Using similar structure to surface code for consistency
+        result.n_ancilla = params.k * (Math.pow(result.d - 1, 2) + 2 * (result.d - 1));
+        
+        // Calculate logical error rate using the color code formula
+        // LFR_color ≈ A * k * (p/p_th_color)^⌈d/2⌉
+        result.epsilon_L = 0.03 * params.k * Math.pow(p_ratio, Math.ceil(result.d / 2));
+        
+        // Always include k and n in results
+        result.k = params.k;
+        result.n = params.n;
+        
+        return result;
+      }
+    },
     hypergraph: {
       name: 'Hypergraph Product Code',
       threshold: 0.006, // 0.6%

--- a/src/App.js
+++ b/src/App.js
@@ -684,6 +684,7 @@ const QuantumCalculator = () => {
             <li><span style={{color: 'rgb(75, 192, 192)'}} className="font-medium">Surface Code:</span> p_th = {(codeLibrary['surface'].threshold * 100).toFixed(2)}%</li>
             <li><span style={{color: 'rgb(255, 99, 132)'}} className="font-medium">Hypergraph Product Code:</span> p_th = {(codeLibrary['hypergraph'].threshold * 100).toFixed(2)}%</li>
             <li><span style={{color: 'rgb(255, 159, 64)'}} className="font-medium">Lifted Product Code:</span> p_th = {(codeLibrary['lifted'].threshold * 100).toFixed(2)}%</li>
+            <li><span style={{color: 'rgb(147, 51, 234)'}} className="font-medium">Color Code:</span> p_th = {(codeLibrary['color'].threshold * 100).toFixed(2)}%</li>
           </ul>
           <p className="mt-2 text-xs italic">Note: The vertical dashed lines show each code's threshold. No quantum error correction code can work when the physical error rate exceeds its threshold - this is why the curves end at these lines.</p>
         </div>
@@ -944,6 +945,19 @@ const QuantumCalculator = () => {
               <li>Threshold ≈ 0.0066 or 0.66%</li>
             </ul>
             <p className="mt-2 text-sm text-gray-500">Source for HGP and LP codes: <a href="https://arxiv.org/abs/2308.08648v1" className="text-blue-600 hover:underline">Constant-Overhead Fault-Tolerant Quantum Computation with Reconfigurable Atom Arrays (Xu et al., 2023)</a></p>
+          </div>
+
+          <div>
+            <p><b>Color Code:</b> LFR(color) = 0.03k(p/0.0036)^⌈d/2⌉</p>
+            <p>Where:</p>
+            <ul className="list-disc pl-6 mt-2">
+              <li>LFR = Logical Failure Rate (ε_L)</li>
+              <li>k = Number of logical qubits</li>
+              <li>p = Physical error probability</li>
+              <li>d = Code distance, approximately √(n/k) for triangular color codes</li>
+              <li>Threshold ≈ 0.0036 or 0.36% (<a href="https://doi.org/10.1103/PRXQuantum.5.030352" className="text-blue-600 hover:underline">circuit-level noise</a>)</li>
+            </ul>
+            <p className="mt-2 text-sm text-gray-500">Color code formula for triangular honeycomb (6.6.6) patches. Steane code [[7,1,3]] is the d=3 member.</p>
           </div>
           <p><b>LFR:</b> probability that any of the logical qubits fails per code cycle</p>
         </div>


### PR DESCRIPTION
This pull request adds support for the Color Code quantum error correction scheme to the quantum resource calculator web tool. The changes include updates to both the user interface and the calculation logic, ensuring the Color Code is now treated alongside the existing Surface, Hypergraph Product, and Lifted Product codes. The most important changes are:

**Feature Addition: Color Code Support**
* Added Color Code as an option in the list of supported codes in the UI and documentation, with a dedicated formula and threshold for logical failure rate calculations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11) [[2]](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67R125-R150)
* Implemented the calculation logic for Color Code in `src/App.js`, including code distance, ancilla qubit estimation, and logical error rate formula based on the latest literature.

**Visualization and UI Enhancements**
* Updated the plot to display Color Code results with a distinct color and added a vertical dashed line for its threshold, consistent with other codes. [[1]](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67R571-R581) [[2]](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67R624-R637)
* Added Color Code to the list of code thresholds in the legend, ensuring users can compare all supported codes at a glance.

**Documentation and Explanatory Content**
* Expanded the documentation in `README.md` and the in-app help section to include the Color Code formula, parameter definitions, and relevant references, improving clarity for users. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R54) [[2]](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67R949-R961)